### PR TITLE
add automatic container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+---
+name: ci
+
+on:
+  workflow_dispatch:
+  push:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-docker-image-x64:
+    name: x64 image for ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-x64
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  build-docker-image-arm:
+    name: arm image for ${{ github.ref_name }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/
 instance/
 *.egg-info/
 *.db
+.project

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Create data directory with proper permissions
 RUN mkdir -p /app/data && chmod 777 /app/data
 
+# This is where timekpr-webui will store usage data
+VOLUME /app/data
+
 # Copy requirements first to leverage Docker cache
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,6 @@ services:
     volumes:
       - ./data:/app/data
     restart: unless-stopped
+    environment:
+      # if your app needs to run on a subpath, place it here - e.g. /timekpr
+      SCRIPT_NAME: /


### PR DESCRIPTION
Really a nice project you created there!

Wouldn't it be nice if you, me and other users were able to run the latest code changes by pulling the docker image directly? This enables them not only to use docker and docker-compose but also Kubernetes and the likes.

With this PR you will be able to have all code changes automatically dockerized and provisioned in Github's docker registry. Plus you will be able to run the images like so:

docker run --name timekpr-webui --port 5000:5000 -v ./data:/app/data ghcr.io/hiranchaudhuri/timekpr-webui:autobuild-arm

You can see this in action on my fork:
https://github.com/HiranChaudhuri/timekpr-webui/pkgs/container/timekpr-webui
https://github.com/HiranChaudhuri/timekpr-webui/actions/runs/14650506621