### PR TITLE
Fix SSH key errors and schedule sync edge cases

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,15 @@ import json
 import logging
 import pytz
 
-from src.database import db, ManagedUser, UserTimeUsage, Settings, UserWeeklySchedule, UserDailyTimeInterval
+from src.database import (
+    db,
+    ManagedUser,
+    UserTimeUsage,
+    Settings,
+    UserWeeklySchedule,
+    UserDailyTimeInterval,
+    coerce_time_spent_day,
+)
 from src.ssh_helper import SSHClient
 from src.task_manager import BackgroundTaskManager
 
@@ -205,10 +213,16 @@ def logout():
     flash('You have been logged out', 'info')
     return redirect(url_for('login'))
 
-@app.route('/users/add', methods=['POST'])
+@app.route('/users/add', methods=['GET', 'POST'])
 def add_user():
     if not session.get('logged_in'):
+        if request.method == 'GET':
+            flash('Please login first', 'warning')
+            return redirect(url_for('login'))
         return jsonify({'success': False, 'message': 'Not authenticated'}), 401
+
+    if request.method == 'GET':
+        return redirect(url_for('admin'))
     
     username = request.form.get('username')
     system_ip = request.form.get('system_ip')
@@ -243,7 +257,7 @@ def add_user():
         
         # Add today's usage data
         today = date.today()
-        time_spent = config_dict.get('TIME_SPENT_DAY', 0)
+        time_spent = coerce_time_spent_day(config_dict.get('TIME_SPENT_DAY', 0))
         
         usage = UserTimeUsage(
             user_id=new_user.id,
@@ -280,7 +294,7 @@ def validate_user(user_id):
         
         # Update today's usage data
         today = date.today()
-        time_spent = config_dict.get('TIME_SPENT_DAY', 0)
+        time_spent = coerce_time_spent_day(config_dict.get('TIME_SPENT_DAY', 0))
         
         # Look for an existing record for today
         usage = UserTimeUsage.query.filter_by(

--- a/src/database.py
+++ b/src/database.py
@@ -5,6 +5,23 @@ import bcrypt
 
 db = SQLAlchemy()
 
+
+def coerce_time_spent_day(value):
+    """Normalise TIME_SPENT_DAY (sortie timekpra) en entier pour la colonne time_spent."""
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (list, tuple)):
+        return coerce_time_spent_day(value[0]) if value else 0
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return 0
+
+
 class Settings(db.Model):
     __tablename__ = 'settings'
     id = db.Column(db.Integer, primary_key=True)

--- a/src/ssh_helper.py
+++ b/src/ssh_helper.py
@@ -40,6 +40,7 @@ class SSHClient:
         Check if a user exists by running the timekpra --userinfo command
         Returns: (is_valid, message, config_dict)
         """
+        client = None
         try:
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -84,10 +85,11 @@ class SSHClient:
         except Exception as e:
             return False, f"Connection error: {str(e)}", None
         finally:
-            try:
-                client.close()
-            except:
-                pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
     
     def _parse_timekpr_output(self, output):
         """Parse the output of timekpra --userinfo command into a dictionary"""
@@ -131,6 +133,7 @@ class SSHClient:
         if operation not in ['+', '-']:
             return False, "Invalid operation. Must be '+' or '-'"
         
+        client = None
         try:
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -170,10 +173,11 @@ class SSHClient:
         except Exception as e:
             return False, f"Connection error: {str(e)}"
         finally:
-            try:
-                client.close()
-            except:
-                pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
     
     def set_weekly_time_limits(self, username, schedule_dict):
         """
@@ -185,6 +189,7 @@ class SSHClient:
         import logging
         logger = logging.getLogger(__name__)
         
+        client = None
         try:
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -301,10 +306,11 @@ class SSHClient:
             logger.error(f"Exception in set_weekly_time_limits: {str(e)}")
             return False, f"Connection error: {str(e)}"
         finally:
-            try:
-                client.close()
-            except:
-                pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
     
     def set_allowed_hours(self, username, intervals_dict):
         """
@@ -316,6 +322,7 @@ class SSHClient:
         import logging
         logger = logging.getLogger(__name__)
         
+        client = None
         try:
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -428,7 +435,8 @@ class SSHClient:
             logger.error(f"Exception in set_allowed_hours: {str(e)}")
             return False, f"Connection error: {str(e)}"
         finally:
-            try:
-                client.close()
-            except:
-                pass
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass

--- a/src/task_manager.py
+++ b/src/task_manager.py
@@ -6,7 +6,15 @@ import logging
 import json
 import traceback
 
-from src.database import db, ManagedUser, UserTimeUsage, Settings, UserWeeklySchedule, UserDailyTimeInterval
+from src.database import (
+    db,
+    ManagedUser,
+    UserTimeUsage,
+    Settings,
+    UserWeeklySchedule,
+    UserDailyTimeInterval,
+    coerce_time_spent_day,
+)
 from src.ssh_helper import SSHClient
 
 logger = logging.getLogger(__name__)
@@ -145,19 +153,37 @@ class BackgroundTaskManager:
                     
                     # Check if there's a pending weekly schedule sync
                     if user.weekly_schedule and not user.weekly_schedule.is_synced:
-                        logger.info(f"Attempting to sync weekly schedule for {user.username}")
-                        
                         schedule_dict = user.weekly_schedule.get_schedule_dict()
                         logger.info(f"DEBUG - schedule_dict from database: {schedule_dict}")
-                        success, message = ssh_client.set_weekly_time_limits(user.username, schedule_dict)
-                        
-                        if success:
-                            logger.info(f"Successfully synced weekly schedule for {user.username}")
+                        _week_days = (
+                            'monday', 'tuesday', 'wednesday', 'thursday',
+                            'friday', 'saturday', 'sunday',
+                        )
+                        has_positive_limits = any(
+                            (schedule_dict.get(d, 0) or 0) > 0 for d in _week_days
+                        )
+                        # set_weekly_time_limits rejects "all zero" — nothing to push; avoid endless WARNING loop
+                        if not has_positive_limits:
+                            logger.info(
+                                "No daily limits > 0 in UI for %s; marking weekly schedule synced (remote unchanged)",
+                                user.username,
+                            )
                             user.weekly_schedule.mark_synced()
                             db.session.commit()
-                            logger.info("Marked weekly schedule as synced in database")
                         else:
-                            logger.warning(f"Failed to sync weekly schedule for {user.username}: {message}")
+                            logger.info(f"Attempting to sync weekly schedule for {user.username}")
+                            success, message = ssh_client.set_weekly_time_limits(
+                                user.username, schedule_dict
+                            )
+                            if success:
+                                logger.info(f"Successfully synced weekly schedule for {user.username}")
+                                user.weekly_schedule.mark_synced()
+                                db.session.commit()
+                                logger.info("Marked weekly schedule as synced in database")
+                            else:
+                                logger.warning(
+                                    f"Failed to sync weekly schedule for {user.username}: {message}"
+                                )
                     else:
                         if user.weekly_schedule:
                             logger.info(f"Weekly schedule already synced for {user.username}")
@@ -206,7 +232,7 @@ class BackgroundTaskManager:
                             
                             # Update or create today's usage data
                             today = date.today()
-                            time_spent = config_dict.get('TIME_SPENT_DAY', 0)
+                            time_spent = coerce_time_spent_day(config_dict.get('TIME_SPENT_DAY', 0))
                             
                             # Look for an existing record for today
                             usage = UserTimeUsage.query.filter_by(


### PR DESCRIPTION
## Summary

This PR fixes several edge cases around remote SSH operations and schedule synchronization:

- Guard SSH client cleanup in `finally` blocks to avoid crashes when client initialization fails.
- Normalize `TIME_SPENT_DAY` values before persisting to integer DB fields.
- Make `/users/add` safe on GET requests (redirect instead of error-prone behavior).
- Treat all-zero weekly schedules as "nothing to push" to avoid endless sync warning loops.
- Keep background updates and usage persistence consistent.

## Why

In real deployments (remote Timekpr host over SSH), these cases caused:
- repeated SSH key-related failures and fragile error handling,
- potential DB type issues from parsed `TIME_SPENT_DAY`,
- confusing schedule sync states and noisy warning loops.

## Manual validation

- SSH auth path tested with key-based auth to remote `timekpra`.
- User add/validate flow tested from the admin UI.
- Weekly schedule sync tested for both non-zero limits and all-zero schedules.
- Background task logs checked for stable sync behavior and no repeated warning loops.
